### PR TITLE
Use mirrorlist.c.o instead of mirror.c.o

### DIFF
--- a/CentOS-Ceph-Nautilus.repo
+++ b/CentOS-Ceph-Nautilus.repo
@@ -5,7 +5,8 @@
 
 [centos-ceph-nautilus]
 name=CentOS-$releasever - Ceph Nautilus
-baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/ceph-nautilus/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=storage-ceph-nautilus
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/ceph-nautilus/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage

--- a/centos-release-ceph-nautilus.spec
+++ b/centos-release-ceph-nautilus.spec
@@ -1,7 +1,7 @@
 Summary: Ceph Nautilus packages from the CentOS Storage SIG repository
 Name: centos-release-ceph-nautilus
 Version: 1.1
-Release: 3%{?dist}
+Release: 5%{?dist}
 License: GPLv2
 URL: http://wiki.centos.org/SpecialInterestGroup/Storage
 Source0: CentOS-Ceph-Nautilus.repo
@@ -28,6 +28,12 @@ install -D -m 644 %{SOURCE0} %{buildroot}%{_sysconfdir}/yum.repos.d/CentOS-Ceph-
 %config(noreplace) %{_sysconfdir}/yum.repos.d/CentOS-Ceph-Nautilus.repo
 
 %changelog
+* Wed Dec 05 2018 Anssi Johansson <avij@centosproject.org> - 1.1-5
+- Use mirrorlist.c.o instead of mirror.c.o
+
+* Tue Dec 04 2018 Ken Dreyer <kdreyer@redhat.com> - 1.1-4
+- Fix some stray Luminous references
+
 * Tue Dec 04 2018 Ken Dreyer <kdreyer@redhat.com> - 1.1-3
 - Bumping for Nautilus
 


### PR DESCRIPTION
You can now use mirrorlist.centos.org instead of mirror.centos.org for the content. For example, see http://mirrorlist.centos.org/?release=7&arch=ppc64le&repo=storage-ceph-luminous and http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=storage-ceph-luminous

The storage-ceph-nautilus repository will automatically become available on mirrorlist.centos.org once the repository hits mirror.centos.org.

Most of mirror.centos.org hosts are also used for seeding the 600+ external mirrors we have. By directing some of their download traffic to external mirrors we can offer faster sync speeds for those external mirrors, and for people downloading individual rpms from mirror.centos.org. Second, most of those external mirrors offer faster download speeds to end users than what could be achieved by downloading from mirror.centos.org, so the users will benefit from this change as well. Finally, because there are much more external mirrors than mirror.centos.org  nodes, it is likely that your bits will need to travel a shorter path, conserving bandwidth globally.